### PR TITLE
Modify StaticClass lookups to use hashes of the full name instead of idx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ set(UE4_SOURCE_DIR "${CMAKE_SOURCE_DIR}/Source" CACHE PATH "Where the UE4 source
 set(SDK_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/sdk" CACHE PATH "Where the generated SDK files will go")
 set(CONFIG_HPP "DRGConfig.hpp" CACHE STRING "The config header file to use")
 set(SDK_ADDITIONAL_INCLUDE_HPP "" CACHE STRING "An optional additional header to include in every generated file")
+set(SDK_UOBJECT_STRING_LOOKUP OFF CACHE BOOL "Whether to perform StaticClass lookups with strings instead of hashes")
 add_library(ue4genny SHARED 
     "src/kanan/core/Memory.cpp"
     "src/kanan/core/Module.cpp"
@@ -45,5 +46,8 @@ target_compile_definitions(ue4genny PUBLIC
 )
 if(SDK_ADDITIONAL_INCLUDE_HPP)
     target_compile_definitions(ue4genny PUBLIC SDK_ADDITIONAL_INCLUDE_HPP="${SDK_ADDITIONAL_INCLUDE_HPP}")
+endif()
+if(SDK_UOBJECT_STRING_LOOKUP)
+    target_compile_definitions(ue4genny PUBLIC SDK_UOBJECT_STRING_LOOKUP)
 endif()
 target_compile_features(ue4genny PUBLIC cxx_std_17)

--- a/src/UE4Genny.hpp
+++ b/src/UE4Genny.hpp
@@ -5,7 +5,8 @@
 #include "UObject/UObjectArray.h"
 
 FUObjectArray* get_GUObjectArray();
-UObjectBase* find_object(const char* obj_path);
+UObjectBase* find_uobject(const char* obj_path);
+UObjectBase* find_uobject(size_t obj_path_hash);
 std::string narrow(const FString& fstr);
 std::string narrow(const FName& fname);
 

--- a/src/UE4Impl.cpp
+++ b/src/UE4Impl.cpp
@@ -16,23 +16,23 @@ size_t FMemory::QuantizeSize(size_t size, uint32_t) {
 }
 
 UClass* UStruct::GetPrivateStaticClass() {
-    return (UClass*)find_object("Class /Script/CoreUObject.Struct");
+    return (UClass*)find_uobject("Class /Script/CoreUObject.Struct");
 }
 
 UClass* UClass::GetPrivateStaticClass() {
-    return (UClass*)find_object("Class /Script/CoreUObject.Class");
+    return (UClass*)find_uobject("Class /Script/CoreUObject.Class");
 }
 
 UClass* UScriptStruct::GetPrivateStaticClass() {
-    return (UClass*)find_object("Class /Script/CoreUObject.ScriptStruct");
+    return (UClass*)find_uobject("Class /Script/CoreUObject.ScriptStruct");
 }
 
 UClass* UEnum::GetPrivateStaticClass() {
-    return (UClass*)find_object("Class /Script/CoreUObject.Enum");
+    return (UClass*)find_uobject("Class /Script/CoreUObject.Enum");
 }
 
 UClass* UFunction::GetPrivateStaticClass() {
-    return (UClass*)find_object("Class /Script/CoreUObject.Function");
+    return (UClass*)find_uobject("Class /Script/CoreUObject.Function");
 }
 
 FString FName::ToString() const {

--- a/src/kanan/core/String.hpp
+++ b/src/kanan/core/String.hpp
@@ -16,4 +16,16 @@ std::wstring widen(std::string_view str);
 std::string formatString(const char* format, va_list args);
 
 std::vector<std::string> split(std::string str, const std::string& delim);
+
+// FNV-1a
+static constexpr auto hash(std::string_view data) {
+    size_t result = 0xcbf29ce484222325;
+
+    for (char c : data) {
+        result ^= c;
+        result *= (size_t)1099511628211;
+    }
+
+    return result;
+}
 } // namespace kanan


### PR DESCRIPTION
There was an issue in the game I was working on where the generated indices did not correspond to the correct object. The object would be random after every restart of the game. So, I made it look up the object based on its name instead.

This will require the project using the SDK to implement `find_uobject`.